### PR TITLE
chore(playground): improve scroll area behavior

### DIFF
--- a/packages/playground/src/components/editor/Editor.test.tsx
+++ b/packages/playground/src/components/editor/Editor.test.tsx
@@ -137,6 +137,7 @@ describe('Editor', () => {
     expect(options.readOnly).toBe(false)
     expect(options.minimap.enabled).toBe(true)
     expect(options.lineNumbers).toBe('on')
+    expect(options.scrollBeyondLastLine).toBe(false)
   })
 
   it('renders correctly with custom props', () => {

--- a/packages/playground/src/components/editor/Editor.tsx
+++ b/packages/playground/src/components/editor/Editor.tsx
@@ -421,6 +421,7 @@ export function Editor({
         automaticLayout: true,
         roundedSelection: false,
         smoothScrolling: true,
+        scrollBeyondLastLine: false,
       }}
     />
   )


### PR DESCRIPTION
While I was using the playground to edit my resume and watching the real-time preview on the right, I noticed that the scrolling behavior in the left YAML panel was a bit unusual. The height of the scrolling area was significantly greater than the content height of the YAML. This caused a large blank space to appear when I scrolled to the very bottom, which somewhat affected my user experience, so I made some minor adjustments.

pls review @xiaohanyu 

btw, Happy Chinese New Year！

## before

<img width="3024" height="1648" alt="image" src="https://github.com/user-attachments/assets/93819709-0783-4363-9d4a-bd31fcc95d30" />

## after

<img width="3022" height="1804" alt="image" src="https://github.com/user-attachments/assets/6e596250-dff1-4389-b5c6-ced1a26f3d70" />