### PR TITLE
fix(playground): resolve @yamlresume/core type definition issue in dev

### DIFF
--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -5,10 +5,12 @@
     "outDir": "dist",
     "jsx": "react-jsx",
     "paths": {
-      "@/*": ["src/*"],
-      "@yamlresume/core": ["../core/src/index.ts"]
+      "@/*": ["src/*"]
     },
     "importHelpers": false
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "references": [
+    { "path": "../core" }
+  ]
   }


### PR DESCRIPTION
In the development of monorepo projects, we prefer to directly reference the source code of packages rather than the built artifacts, which provides the best experience for hot updates and jumping to source code. Therefore, we have made minor adjustments to the tsconfig of `yamlresume/core`.

## Before

<img width="956" height="124" alt="image" src="https://github.com/user-attachments/assets/af3f1e7a-d69d-4f93-8152-e80f62439e02" />

<img width="3024" height="1834" alt="image" src="https://github.com/user-attachments/assets/37b5ba21-53c6-41d1-acfb-42454942eae1" />

## After

<img width="1584" height="1130" alt="image" src="https://github.com/user-attachments/assets/2683941b-60ff-49cf-a9ce-29816312b89a" />