### PR TITLE
fix: revise moderncv's \homepage implementation to accept generalized URLs.

### DIFF
--- a/packages/core/src/renderer/latex/moderncv.test.ts
+++ b/packages/core/src/renderer/latex/moderncv.test.ts
@@ -512,6 +512,38 @@ describe('ModerncvBase', () => {
         expect(result).toContain('\\urlstyle{same}')
       })
     })
+
+    describe('homepage redefinition', () => {
+      it('should include httplink and httpslink patches in preamble', () => {
+        const result = renderer.renderPreamble()
+
+        expect(result).toContain(
+          'Patch \\httplink and \\httpslink to handle full URLs'
+        )
+        expect(result).toContain('\\RenewDocumentCommand{\\httpslink}{O{}m}')
+        expect(result).toContain('\\RenewDocumentCommand{\\httplink}{O{}m}')
+      })
+
+      it('should use str_set:Nx for macro expansion and str_if_in for detection', () => {
+        const result = renderer.renderPreamble()
+
+        // Using \str_set:Nx to expand macros like \@homepage before checking
+        expect(result).toContain('\\str_set:Nx \\g_yamlresume_url_str {#2}')
+        // Using \str_if_in:NnTF for correct protocol detection
+        expect(result).toContain(
+          '\\str_if_in:NnTF \\g_yamlresume_url_str {://}'
+        )
+      })
+
+      it('should use url command for URLs with and without protocol', () => {
+        const result = renderer.renderPreamble()
+
+        // Should use \url for both cases (with and without protocol)
+        expect(result).toContain('{ \\url{#2} }')
+        expect(result).toContain('{ \\url{https://#2} }')
+        expect(result).toContain('{ \\url{http://#2} }')
+      })
+    })
   })
 
   describe('ModerncvStyle', () => {

--- a/packages/core/src/renderer/latex/moderncv.ts
+++ b/packages/core/src/renderer/latex/moderncv.ts
@@ -345,6 +345,9 @@ ${fontList
 
       // URL styling - use same font as surrounding text instead of monospace
       this.renderUrlConfig(),
+
+      // Patch httplink/httpslink to support full URLs with protocols
+      this.renderHomepageRedefinition(),
     ])
   }
 
@@ -354,6 +357,51 @@ ${fontList
   private renderUrlConfig(): string {
     return `%% URL styling - use normal text instead of monospace
 \\urlstyle{same}`
+  }
+
+  /**
+   * Render a redefinition of \httplink and \httpslink to support full URLs.
+   *
+   * The original moderncv \httplink and \httpslink macros always prepend
+   * the protocol (http:// or https://) to the URL. This causes issues when
+   * the URL already contains a protocol (e.g., https://example.com), resulting
+   * in malformed URLs like https://https://example.com.
+   *
+   * This redefinition checks if the URL already contains "://" and if so,
+   * uses the URL directly without prepending the protocol.
+   *
+   * Note: We use \str_set:Nx (with x-expansion) to fully expand the argument
+   * before converting to a string. This is necessary because moderncv passes
+   * the URL via a macro (\@homepage), and without expansion we would be
+   * checking the literal string "\@homepage" instead of its value.
+   * We then use \str_if_in:NnTF to check for "://" in the expanded URL.
+   *
+   * @returns The LaTeX code for the httplink/httpslink redefinition
+   */
+  private renderHomepageRedefinition(): string {
+    return `%% Patch \\httplink and \\httpslink to handle full URLs
+% The original moderncv macros always prepend http:// or https:// to URLs.
+% This causes issues when the URL already has a protocol (e.g., https://example.com)
+% resulting in malformed URLs like https://https://example.com.
+% This patch checks if the URL already contains "://" and uses it directly if so.
+% Note: We use \\str_set:Nx (x-expansion) to expand macros like \\@homepage first.
+\\ExplSyntaxOn
+\\str_new:N \\g_yamlresume_url_str
+
+\\RenewDocumentCommand{\\httpslink}{O{}m}{
+  \\str_set:Nx \\g_yamlresume_url_str {#2}
+  \\str_if_in:NnTF \\g_yamlresume_url_str {://}
+    { \\url{#2} }
+    { \\url{https://#2} }
+}
+
+\\RenewDocumentCommand{\\httplink}{O{}m}{
+  \\str_set:Nx \\g_yamlresume_url_str {#2}
+  \\str_if_in:NnTF \\g_yamlresume_url_str {://}
+    { \\url{#2} }
+    { \\url{http://#2} }
+}
+\\ExplSyntaxOff`
   }
 
   /**


### PR DESCRIPTION
Split these PR to 2 commits:

1. https://github.com/yamlresume/yamlresume/pull/165/changes/8e082e24aeb62992b0bd759653e21bb470be60b1: use `\url` to replace `\href` as all URLs has no anchor text, so no need to use `\href`
2. https://github.com/yamlresume/yamlresume/pull/165/changes/ed4617d1ace9121c713afa0133828f850d29e360: revise moderncv's `\homepage` macro, check the commit message, the code comments for details.

